### PR TITLE
Add shell completions for bash, zsh, and fish

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -41,6 +41,7 @@ archives:
     files:
       - LICENSE
       - README.md
+      - completions/*
     rlcp: true
 
 
@@ -59,6 +60,10 @@ brews:
     homepage: "https://echo.umputun.com"
     description: "Responds with json-formatted echo of the incoming request and with a predefined message."
     license: "MIT"
+    extra_install: |
+      bash_completion.install "completions/echo-http.bash" => "echo-http"
+      zsh_completion.install "completions/echo-http.zsh" => "_echo-http"
+      fish_completion.install "completions/echo-http.fish" => "echo-http.fish"
 
 nfpms:
   - id: echo-http
@@ -76,3 +81,10 @@ nfpms:
     bindir: /usr/bin
     epoch: 1
     release: 1
+    contents:
+      - src: completions/echo-http.bash
+        dst: /usr/share/bash-completion/completions/echo-http
+      - src: completions/echo-http.zsh
+        dst: /usr/share/zsh/vendor-completions/_echo-http
+      - src: completions/echo-http.fish
+        dst: /usr/share/fish/vendor_completions.d/echo-http.fish

--- a/completions/echo-http.bash
+++ b/completions/echo-http.bash
@@ -1,8 +1,7 @@
 # bash completion for echo-http (generated via go-flags)
 _echo_http() {
     local args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
-    local IFS=$'\n'
-    COMPREPLY=($(GO_FLAGS_COMPLETION=1 "${COMP_WORDS[0]}" "${args[@]}" 2>/dev/null))
+    mapfile -t COMPREPLY < <(GO_FLAGS_COMPLETION=1 "${COMP_WORDS[0]}" "${args[@]}" 2>/dev/null)
     return 0
 }
 complete -o default -F _echo_http echo-http

--- a/completions/echo-http.bash
+++ b/completions/echo-http.bash
@@ -1,0 +1,8 @@
+# bash completion for echo-http (generated via go-flags)
+_echo_http() {
+    local args=("${COMP_WORDS[@]:1:$COMP_CWORD}")
+    local IFS=$'\n'
+    COMPREPLY=($(GO_FLAGS_COMPLETION=1 "${COMP_WORDS[0]}" "${args[@]}" 2>/dev/null))
+    return 0
+}
+complete -o default -F _echo_http echo-http

--- a/completions/echo-http.fish
+++ b/completions/echo-http.fish
@@ -1,0 +1,2 @@
+# fish completion for echo-http (generated via go-flags)
+complete -c echo-http -a '(GO_FLAGS_COMPLETION=1 echo-http (commandline -cop) 2>/dev/null)'

--- a/completions/echo-http.fish
+++ b/completions/echo-http.fish
@@ -1,2 +1,2 @@
 # fish completion for echo-http (generated via go-flags)
-complete -c echo-http -a '(GO_FLAGS_COMPLETION=1 echo-http (commandline -cop) 2>/dev/null)'
+complete -c echo-http -a '(GO_FLAGS_COMPLETION=verbose echo-http (commandline -cop) 2>/dev/null | string replace -r "\\s+# " "\t")'

--- a/completions/echo-http.zsh
+++ b/completions/echo-http.zsh
@@ -2,11 +2,24 @@
 
 # zsh completion for echo-http (generated via go-flags)
 _echo_http() {
-    local IFS=$'\n'
-    local -a completions
-    completions=($(GO_FLAGS_COMPLETION=1 "${words[1]}" "${(@)words[2,$CURRENT]}" 2>/dev/null))
-    if (( ${#completions} )); then
-        compadd -- "${completions[@]}"
+    local -a lines
+    lines=(${(f)"$(GO_FLAGS_COMPLETION=verbose "${words[1]}" "${(@)words[2,$CURRENT]}" 2>/dev/null)"})
+    if (( ${#lines} )); then
+        local -a descr
+        local line item desc
+        for line in "${lines[@]}"; do
+            if [[ "$line" = *'  # '* ]]; then
+                item="${line%%  *}"
+                desc="${line#*  \# }"
+                descr+=("${item//:/\\:}:${desc}")
+            else
+                item="${line%%  *}"
+                [[ -z "$item" ]] && item="$line"
+                [[ "$item" = *" "* ]] && continue
+                descr+=("${item//:/\\:}")
+            fi
+        done
+        _describe 'command' descr
     else
         _files
     fi

--- a/completions/echo-http.zsh
+++ b/completions/echo-http.zsh
@@ -1,0 +1,15 @@
+#compdef echo-http
+
+# zsh completion for echo-http (generated via go-flags)
+_echo_http() {
+    local IFS=$'\n'
+    local -a completions
+    completions=($(GO_FLAGS_COMPLETION=1 "${words[1]}" "${(@)words[2,$CURRENT]}" 2>/dev/null))
+    if (( ${#completions} )); then
+        compadd -- "${completions[@]}"
+    else
+        _files
+    fi
+}
+
+_echo_http "$@"

--- a/main.go
+++ b/main.go
@@ -26,7 +26,9 @@ var opts struct {
 var revision = "local"
 
 func main() {
-	fmt.Printf("echo-http %s\n", revision)
+	if os.Getenv("GO_FLAGS_COMPLETION") == "" {
+		fmt.Printf("echo-http %s\n", revision)
+	}
 
 	p := flags.NewParser(&opts, flags.PrintErrors|flags.PassDoubleDash|flags.HelpFlag)
 	p.SubcommandsOptional = true


### PR DESCRIPTION
## Summary

- Add completion wrapper scripts for bash, zsh, and fish that use go-flags' built-in `GO_FLAGS_COMPLETION` mechanism
- Update `.goreleaser.yml` to include completions in release archives, Homebrew formula (`extra_install`), and deb/rpm packages (`contents`)
- Suppress version banner when running in completion mode to avoid polluting output

After this, `brew install umputun/apps/echo-http` will automatically install shell completions.