### PR TITLE
ci: harden workflows, upgrade actions, fix caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,24 @@ on:
     tags:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: set up go 1.24
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.24"
         id: go
-
-      - name: checkout
-        uses: actions/checkout@v4
 
       - name: build and test
         run: |
@@ -28,25 +33,23 @@ jobs:
           TZ: "America/Chicago"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1
-
-      - name: install goveralls
-        run: go install github.com/mattn/goveralls@latest
+          version: "v2.11.1"
 
       - name: submit coverage
         run: |
+          go install github.com/mattn/goveralls@latest
           goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: available platforms
         run: echo ${{ steps.buildx.outputs.platforms }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,25 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
       - name: check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: set up go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: "1.22"
+          go-version: "1.24"
 
       - name: run goreleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: ~> 1.25
           args: release --clean

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       - name: check out code
         uses: actions/checkout@v6
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: set up go


### PR DESCRIPTION
## Changes
- Reorder checkout before setup-go for proper dependency caching
- Upgrade all GitHub Actions to latest versions (checkout@v6, setup-go@v6, golangci-lint-action@v9, goreleaser-action@v7, setup-qemu@v4, setup-buildx@v4)
- Add `permissions: contents: read` for CI, `permissions: contents: write` for release
- Add `persist-credentials: false` to checkout steps
- Add `fetch-depth: 0` to release.yml checkout for goreleaser — it needs full git history for changelog generation and tag resolution (see https://goreleaser.com/ci/actions/)
- Fix goveralls pattern (combined install + submit)
- Update release.yml Go version from 1.22 to 1.24 to match go.mod
- Upgrade golangci-lint to v2.11.1

Verified golangci-lint passes with v2.11.1.